### PR TITLE
Adds tox.ini and basic rock test

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -18,6 +18,12 @@ jobs:
       rockcraft-revisions: '{"amd64": "1783", "arm64": "1784"}'
       arch-skipping-maximize-build-space: '["arm64"]'
       platform-labels: '{"arm64": ["self-hosted", "Linux", "ARM64", "jammy"]}'
+  run-tests:
+    uses: canonical/k8s-workflows/.github/workflows/run_tests.yaml@main
+    needs: [build-and-push-arch-specifics]
+    secrets: inherit
+    with:
+      rock-metas: ${{ needs.build-and-push-arch-specifics.outputs.rock-metas }}
   scan-images:
     uses: canonical/k8s-workflows/.github/workflows/scan_images.yaml@main
     needs: [build-and-push-arch-specifics]

--- a/tests/.copyright.tmpl
+++ b/tests/.copyright.tmpl
@@ -1,0 +1,1 @@
+Copyright ${years} ${owner}.

--- a/tests/integration/test_sriov_net_device_plugin.py
+++ b/tests/integration/test_sriov_net_device_plugin.py
@@ -1,0 +1,7 @@
+#
+# Copyright 2024 Canonical, Ltd.
+#
+
+
+def test_integration_sriov_dpdk():
+    pass

--- a/tests/requirements-dev.txt
+++ b/tests/requirements-dev.txt
@@ -1,0 +1,5 @@
+black==24.3.0
+codespell==2.2.4
+flake8==6.0.0
+isort==5.12.0
+licenseheaders==0.8.8

--- a/tests/requirements-test.txt
+++ b/tests/requirements-test.txt
@@ -1,0 +1,5 @@
+coverage[toml]==7.2.5
+pytest==7.3.1
+PyYAML==6.0.1
+tenacity==8.2.3
+git+https://github.com/canonical/k8s-test-harness.git@main

--- a/tests/sanity/test_sriov_net_device_plugin.py
+++ b/tests/sanity/test_sriov_net_device_plugin.py
@@ -1,0 +1,35 @@
+#
+# Copyright 2024 Canonical, Ltd.
+#
+
+from k8s_test_harness.util import docker_util, env_util
+
+ROCK_EXPECTED_FILES = [
+    "/entrypoint.sh",
+    "/usr/bin/ddptool",
+    "/usr/bin/sriovdp",
+]
+
+
+def test_sriov_dpdk_rock():
+    """Test SRIOV Network Device Plugin rock."""
+
+    rock = env_util.get_build_meta_info_for_rock_version(
+        "sriov-net-device-plugin", "3.6.2", "amd64"
+    )
+    image = rock.image
+
+    # check rock filesystem.
+    docker_util.ensure_image_contains_paths(image, ROCK_EXPECTED_FILES)
+
+    # check binary.
+    process = docker_util.run_in_docker(image, ["sriovdp", "--help"], False)
+    assert "Usage of sriovdp:" in process.stderr
+
+    # check ddptool and version.
+    process = docker_util.run_in_docker(image, ["ddptool", "--version"], False)
+    assert "DDPTool version 1.0.1.12" in process.stdout
+
+    # check /entrypoint.sh script.
+    process = docker_util.run_in_docker(image, ["/entrypoint.sh"], False)
+    assert "open /etc/pcidp/config.json: no such file or directory" in process.stderr

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -1,0 +1,72 @@
+[tox]
+no_package = True
+skip_missing_interpreters = True
+env_list = format, lint, integration
+min_version = 4.0.0
+
+[testenv]
+set_env =
+    PYTHONBREAKPOINT=pdb.set_trace
+    PY_COLORS=1
+pass_env =
+    PYTHONPATH
+
+[testenv:format]
+description = Apply coding style standards to code
+deps = -r {tox_root}/requirements-dev.txt
+commands =
+    licenseheaders -t {tox_root}/.copyright.tmpl -cy -o 'Canonical, Ltd' -d {tox_root}/sanity
+    licenseheaders -t {tox_root}/.copyright.tmpl -cy -o 'Canonical, Ltd' -d {tox_root}/integration
+    isort {tox_root}/sanity {tox_root}/integration --profile=black
+    black {tox_root}/sanity {tox_root}/integration
+
+[testenv:lint]
+description = Check code against coding style standards
+deps = -r {tox_root}/requirements-dev.txt
+commands =
+    codespell {tox_root}/sanity {tox_root}/integration
+    flake8 {tox_root}/sanity {tox_root}/integration
+    licenseheaders -t {tox_root}/.copyright.tmpl -cy -o 'Canonical, Ltd' -d {tox_root}/sanity --dry
+    licenseheaders -t {tox_root}/.copyright.tmpl -cy -o 'Canonical, Ltd' -d {tox_root}/integration --dry
+    isort {tox_root}/sanity {tox_root}/integration --profile=black --check
+    black {tox_root}/sanity {tox_root}/integration --check --diff
+
+[testenv:sanity]
+description = Run integration tests
+deps =
+    -r {tox_root}/requirements-test.txt
+commands =
+    pytest -v \
+        --maxfail 1 \
+        --tb native \
+        --log-cli-level DEBUG \
+        --disable-warnings \
+        {posargs} \
+        {tox_root}/sanity
+pass_env =
+    TEST_*
+    ROCK_*
+    BUILT_ROCKS_METADATA
+
+[testenv: integration]
+description = Run integration tests
+deps = -r {tox_root}/requirements-test.txt
+commands =
+    pytest -v \
+        --maxfail 1 \
+        --tb native \
+        --log-cli-level DEBUG \
+        --disable-warnings \
+        {posargs} \
+        {tox_root}/integration
+pass_env =
+    TEST_*
+    ROCK_*
+    BUILT_ROCKS_METADATA
+
+[flake8]
+max-line-length = 120
+select = E,W,F,C,N
+ignore = W503
+exclude = venv,.git,.tox,.tox_env,.venv,build,dist,*.egg_info
+show-source = true


### PR DESCRIPTION
Adds the following tox targets: fmt, lint, sanity, integration.

Adds basic rock test, checking that the expected files exist in the rock, and checking the added executables outputs.