### PR TITLE
Changes rock base to bare

### DIFF
--- a/3.6.2/rockcraft.yaml
+++ b/3.6.2/rockcraft.yaml
@@ -11,9 +11,8 @@ description: |
 license: Apache-2.0
 version: 3.6.2
 
-base: ubuntu@22.04
+base: bare
 build-base: ubuntu@22.04
-run-user: _daemon_
 
 platforms:
   amd64:
@@ -34,6 +33,18 @@ services:
 entrypoint-service: install-cni
 
 parts:
+  add-base-files:
+    plugin: nil
+    stage-packages:
+      - base-files
+      - bash
+      - coreutils
+      - gawk
+    override-build: |
+      # Need to add symlink to awk.
+      mkdir -p $CRAFT_PART_INSTALL/usr/bin
+      ln -s gawk $CRAFT_PART_INSTALL/usr/bin/awk
+
   build-deps:
     plugin: nil
     build-snaps:

--- a/tests/sanity/test_sriov_net_device_plugin.py
+++ b/tests/sanity/test_sriov_net_device_plugin.py
@@ -20,7 +20,7 @@ def test_sriov_dpdk_rock():
     image = rock.image
 
     # check rock filesystem.
-    docker_util.ensure_image_contains_paths(image, ROCK_EXPECTED_FILES)
+    docker_util.ensure_image_contains_paths_bare(image, ROCK_EXPECTED_FILES)
 
     # check binary.
     process = docker_util.run_in_docker(image, ["sriovdp", "--help"], False)
@@ -31,5 +31,5 @@ def test_sriov_dpdk_rock():
     assert "DDPTool version 1.0.1.12" in process.stdout
 
     # check /entrypoint.sh script.
-    process = docker_util.run_in_docker(image, ["/entrypoint.sh"], False)
+    process = docker_util.run_in_docker(image, ["bash", "-x", "/entrypoint.sh"], False)
     assert "open /etc/pcidp/config.json: no such file or directory" in process.stderr

--- a/tests/tox.ini
+++ b/tests/tox.ini
@@ -35,8 +35,10 @@ commands =
 description = Run integration tests
 deps =
     -r {tox_root}/requirements-test.txt
+allowlist_externals =
+    sudo
 commands =
-    pytest -v \
+    sudo -E {envpython} -m pytest -v \
         --maxfail 1 \
         --tb native \
         --log-cli-level DEBUG \


### PR DESCRIPTION
Switching to a bare-based image will reduce the overall image size and reduces attack surface area.

The image is supposed to run a script, thus we need a few packages installed.

``ddptool`` is not statically built, so it still depends on ``/lib`` and ``/lib64``, which is why we're adding ``base-files``.

Switch the container user to root. It is supposed to have access to certain host folders through ``hostPath`` mounts, and thus, it should be able to modify them (e.g.: create ``/var/log/sriovdp`` folder).

We can no longer use ensure_image_contains_paths to check if files exist in the rock images, since they are now bare-based. Instead, we can use ensure_image_contains_paths_bare, which checks the image layers instead. Because of this, we need sufficient permissions to check the ``/var/lib/docker`` folder.